### PR TITLE
fix: continue leader failed should close leader component

### DIFF
--- a/fastflow.go
+++ b/fastflow.go
@@ -152,7 +152,7 @@ func (l *LeaderChangedHandler) Handle(cxt context.Context, e goevent.Event) {
 		log.Println("leader initial")
 	}
 	// continue leader failed
-	if !lcEvent.IsLeader && len(l.leaderCloser) == 0 {
+	if !lcEvent.IsLeader && len(l.leaderCloser) != 0 {
 		l.Close()
 	}
 }


### PR DESCRIPTION
多副本情况下，某副本作为leader续期失败之后，其作为leader的相关component没有关闭。导致多个副本会同时执行相关任务，直观表现为会存在多个dispatch和watchdog同时执行